### PR TITLE
Fjerner restore-keys for å gjøre npm ci raskere

### DIFF
--- a/node-setup/action.yml
+++ b/node-setup/action.yml
@@ -26,8 +26,6 @@ runs:
           ~/node_modules
           ~/**/node_modules
         key: ${{ runner.os }}-node-modules-${{ hashFiles('**/package-lock.json') }}
-        restore-keys: |
-          ${{ runner.os }}-node-modules-
     - if: steps.cache-node-modules.outputs.cache-hit != 'true'
       run: |
         echo "🚚 Packages have changed, need to fetch dependencies"


### PR DESCRIPTION
Fra https://docs.npmjs.com/cli/v8/commands/npm-ci:

> npm ci will be significantly faster when:
>
>    * There is a package-lock.json or npm-shrinkwrap.json file.
>    * The node_modules folder is missing or empty.

Så når vi må kjøre `npm ci` er det antakelig bedre å begynne uten node_modules.