### PR TITLE
Upgrade/refactor node-setup

### DIFF
--- a/node-setup/action.yml
+++ b/node-setup/action.yml
@@ -20,7 +20,6 @@ inputs:
 runs:
   using: "composite"
   steps:
-    - uses: actions/checkout@v2
     - uses: actions/setup-node@v2
       with:
         node-version: ${{ inputs.node-version }}

--- a/node-setup/action.yml
+++ b/node-setup/action.yml
@@ -9,7 +9,6 @@ inputs:
   npm-version:
     description: "NPM version"
     required: false
-    default: "8"
   install-dependencies:
     description: "Whether to install dependencies"
     required: false
@@ -25,7 +24,8 @@ runs:
     - uses: actions/setup-node@v2
       with:
         node-version: ${{ inputs.node-version }}
-    - run: npm install -g npm@${{ inputs.npm-version }}
+    - if: inputs.npm-version
+      run: npm install -g npm@${{ inputs.npm-version }}
       shell: bash
     - id: cache-dependencies
       if: inputs.install-dependencies == 'true' && inputs.cache-dependencies == 'true'

--- a/node-setup/action.yml
+++ b/node-setup/action.yml
@@ -12,15 +12,20 @@ inputs:
 runs:
   using: "composite"
   steps:
-    - id: setup-node
-      uses: actions/setup-node@v3
+    - uses: actions/setup-node@v3
       with:
         node-version: ${{ inputs.node-version }}
-        cache: npm
     - if: inputs.npm-version
       run: npm install -g npm@${{ inputs.npm-version }}
       shell: bash
-    - if: steps.setup-node.outputs.cache-hit != 'true'
+    - id: cache-dependencies
+      uses: actions/cache@v3
+      with:
+        path: |
+          ~/node_modules
+          ~/**/node_modules
+        key: ${{ runner.os }}-node-modules-${{ hashFiles('**/package-lock.json') }}
+    - if: steps.cache-dependencies.outputs.cache-hit != 'true'
       run: |
         npm ci
         npm run postinstall --if-present

--- a/node-setup/action.yml
+++ b/node-setup/action.yml
@@ -9,10 +9,6 @@ inputs:
   npm-version:
     description: "NPM version"
     required: false
-  install-dependencies:
-    description: "Whether to install dependencies"
-    required: false
-    default: "true"
 runs:
   using: "composite"
   steps:
@@ -24,7 +20,7 @@ runs:
     - if: inputs.npm-version
       run: npm install -g npm@${{ inputs.npm-version }}
       shell: bash
-    - if: inputs.install-dependencies == 'true' && steps.setup-node.outputs.cache-hit != 'true'
+    - if: steps.setup-node.outputs.cache-hit != 'true'
       run: |
         npm ci
         npm run postinstall --if-present

--- a/node-setup/action.yml
+++ b/node-setup/action.yml
@@ -13,28 +13,18 @@ inputs:
     description: "Whether to install dependencies"
     required: false
     default: "true"
-  cache-dependencies:
-    description: "Whether to cache dependencies"
-    required: false
-    default: "true"
 runs:
   using: "composite"
   steps:
-    - uses: actions/setup-node@v2
+    - id: setup-node
+      uses: actions/setup-node@v3
       with:
         node-version: ${{ inputs.node-version }}
+        cache: npm
     - if: inputs.npm-version
       run: npm install -g npm@${{ inputs.npm-version }}
       shell: bash
-    - id: cache-dependencies
-      if: inputs.install-dependencies == 'true' && inputs.cache-dependencies == 'true'
-      uses: actions/cache@v3
-      with:
-        path: |
-          ~/node_modules
-          ~/**/node_modules
-        key: ${{ runner.os }}-node-modules-${{ hashFiles('**/package-lock.json') }}
-    - if: inputs.install-dependencies == 'true' && (inputs.cache-dependencies != 'true' || steps.cache-dependencies.outputs.cache-hit != 'true')
+    - if: inputs.install-dependencies == 'true' && steps.setup-node.outputs.cache-hit != 'true'
       run: |
         npm ci
         npm run postinstall --if-present


### PR DESCRIPTION
- Don't install a specific npm version unless `npm-version` is explicitly set, since NPM 8 is now default with NodeJS 16.
- Remove checkout from setup-node, seems out of scope in this action.
- Update to use setup-node@v3 and force dependency caching. In cases where caching is not needed, it's probably easier to use `actions/setup-node@v3` directly.
- Remove install-dependencies option since again, it's just as easy to use `actions/setup-node@v3` directly in those cases.
