### PR TITLE
Bumpe til node 18 som default

### DIFF
--- a/node-setup/action.yml
+++ b/node-setup/action.yml
@@ -5,7 +5,7 @@ inputs:
   node-version:
     description: "NodeJS version"
     required: false
-    default: "16"
+    default: "18"
   npm-version:
     description: "NPM version"
     required: false


### PR DESCRIPTION
Foreslår å bumpe til node 18 som default nå som vercel støtter node 18.

Kan overkjøres lokalt ved å sette node-versjon slik:
```
      - uses: biblioteksentralen/github-actions/node-setup@main
        with:
          node-version: 16
```