### PR TITLE
Bumpe til actions/upload-artifact@v3

### DIFF
--- a/sanity-dataset-backup/action.yml
+++ b/sanity-dataset-backup/action.yml
@@ -44,7 +44,7 @@ runs:
         SANITY_AUTH_TOKEN: ${{ inputs.sanity-read-token }}
       run: npx sanity dataset export ${{ inputs.dataset-name }} backups/${{ env.BACKUP_FILE_NAME }}
     - name: Upload ${{ env.BACKUP_FILE_NAME }} and store for ${{ env.RETENTION_DAYS }} days
-      uses: actions/upload-artifact@v2
+      uses: actions/upload-artifact@v3
       with:
         name: ${{ env.BACKUP_FILE_NAME }}
         path: ${{ inputs.sanity-path }}/backups/${{ env.BACKUP_FILE_NAME }}


### PR DESCRIPTION
Får warnings ala
```
Backup dataset
Node.js 12 actions are deprecated. Please update the following actions to use Node.js 16: actions/upload-artifact@v2. For more information see: https://github.blog/changelog/2022-09-22-github-actions-all-actions-will-begin-running-on-node16-instead-of-node12/.
```
https://github.com/biblioteksentralen/forrigebok/actions/runs/4288093256