### PR TITLE
bump upload-artifact to v4

### DIFF
--- a/sanity-dataset-backup/action.yml
+++ b/sanity-dataset-backup/action.yml
@@ -56,7 +56,7 @@ runs:
         SANITY_AUTH_TOKEN: ${{ inputs.sanity-read-token }}
       run: pnpm exec sanity dataset export ${{ inputs.dataset-name }} backups/${{ env.BACKUP_FILE_NAME }}
     - name: Upload ${{ env.BACKUP_FILE_NAME }} and store for ${{ env.RETENTION_DAYS }} days
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         name: ${{ env.BACKUP_FILE_NAME }}
         path: ${{ inputs.sanity-path }}/backups/${{ env.BACKUP_FILE_NAME }}


### PR DESCRIPTION
Backup jobben feiler pga deprecated versjon av `actions/upload-artifact: v3`

Bumper til v4.