### PR TITLE
backup action: use self contained nodejs

### DIFF
--- a/sanity-dataset-backup/action.yml
+++ b/sanity-dataset-backup/action.yml
@@ -35,13 +35,15 @@ runs:
       run: |
         echo "BACKUP_FILE_NAME=backup-${{ inputs.dataset-name }}-$(date +%Y-%m-%d).tar.gz" >> $GITHUB_ENV
     - uses: actions/checkout@v4
-    - uses: biblioteksentralen/github-actions/node-pnpm-setup@v1
+    - uses: actions/setup-node@v4
+      with:
+        node-version: 22
     - name: Export dataset
       shell: bash
       working-directory: ${{ inputs.sanity-path }}
       env:
         SANITY_AUTH_TOKEN: ${{ inputs.sanity-read-token }}
-      run: pnpm exec sanity dataset export ${{ inputs.dataset-name }} backups/${{ env.BACKUP_FILE_NAME }}
+      run: npx sanity dataset export ${{ inputs.dataset-name }} backups/${{ env.BACKUP_FILE_NAME }}
     - name: Upload ${{ env.BACKUP_FILE_NAME }} and store for ${{ env.RETENTION_DAYS }} days
       uses: actions/upload-artifact@v4
       with:


### PR DESCRIPTION
This action does not need any other dependencies, so it doesn't need "npm install" to have been run and it seems better to just use `actions/setup-node` directly.