### PR TITLE
Midlertidig fiks for å frigjøre plass til dataset backup

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,16 @@
+# $schema: https://json.schemastore.org/dependabot-2.0.json
+# https://docs.github.com/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: /
+    schedule:
+      interval: "weekly"
+      day: "monday"
+      time: "07:00"
+      timezone: "Europe/Oslo"
+    reviewers:
+      - "tjommy"
+      - "winsvold"
+      - "jfulse"
+      - "danmichaelo"

--- a/sanity-dataset-backup/action.yml
+++ b/sanity-dataset-backup/action.yml
@@ -22,6 +22,11 @@ runs:
   using: "composite"
 
   steps:
+    - name: Cleanup before backup
+      run: |
+        sudo apt-get clean
+        sudo rm -rf /usr/share/dotnet /usr/local/lib/android
+        df -h
     - name: Determine retention period
       shell: bash
       run: |


### PR DESCRIPTION
Vi får feilmelding: "no space left on device, write" ved daglig backup av dataset,
![image](https://github.com/user-attachments/assets/ee4fa516-c554-46bc-9b5f-c6beb32caa55)

Tester ut en muligens (midlertidig) løsning: Fjerne noen pakker som ikke er nødvendige for å frigjøre plass under backup-prossessen. Må tenke på noe permanent siden dataset vokser.


