### PR TITLE
Midlertidig fiks for å frigjøre plass til dataset backup

### DIFF
--- a/sanity-dataset-backup/action.yml
+++ b/sanity-dataset-backup/action.yml
@@ -32,6 +32,11 @@ runs:
       uses: biblioteksentralen/github-actions/node-npm-setup@v1
       with:
         node-version: ${{ inputs.node-version }}
+    - name: Remove unecessary packages before backup to save space
+      run: |
+        sudo apt-get clean
+        sudo rm -rf /usr/share/dotnet /usr/local/lib/android
+        df -h
     - name: Determine retention period
       shell: bash
       run: |


### PR DESCRIPTION
Vi får varsel om backup av Libry Content feiler:
https://teams.microsoft.com/l/message/19:3773de2c7f9f4871aee946c1543f1d0d@thread.tacv2/1745801303689?tenantId=301ffa23-94fb-4b44-a341-ffd1b2fcbeb0&groupId=549279e2-fe80-441e-bef9-54842341b566&parentMessageId=1745801303689&teamName=Tjenesteutvikling&channelName=Varsler&createdTime=1745801303689

Dette skyldes: "no space left on device, write" på den daglige backup av dataset til Libry Content,
![image](https://github.com/user-attachments/assets/ee4fa516-c554-46bc-9b5f-c6beb32caa55)

GitHub Actions runner, har en begrenset diskplass på ca 14 GB.
https://docs.github.com/en/actions/using-github-hosted-runners/using-github-hosted-runners/about-github-hosted-runners#standard-github-hosted-runners-for--private-repositories
Tester ut en muligens (og midlertidig) løsning ved å fjerne noen pakker som ikke er nødvendige for å frigjøre plass under backup-prossessen.

Endring: Fjerner foreløpig to pakker som vi ikke har brukt for:
- /usr/share/dotnet
- /usr/local/lib/android


Må tenke på noe permanent siden dataset vokser og vokser.
- Bruker larger runners?
https://docs.github.com/en/actions/using-github-hosted-runners/using-larger-runners/about-larger-runners