### PR TITLE
backups: compression-level: 0 / prevent binary corruption in backups

### DIFF
--- a/sanity-dataset-backup/action.yml
+++ b/sanity-dataset-backup/action.yml
@@ -66,3 +66,5 @@ runs:
         # Fails the workflow if no files are found; defaults to 'warn'
         if-no-files-found: error
         retention-days: ${{ env.RETENTION_DAYS }}
+        # Avoid re-compressing an already-gzipped file, which can corrupt binary content
+        compression-level: 0


### PR DESCRIPTION
- Test-recovery fra [backup-fil i Libry Content](https://github.com/biblioteksentralen/libry-content/actions/workflows/backup.yml) feilet med beskjeden: 

> ReplacementCharError: Unicode replacement character (U+FFFD) found on line 1. This usually indicates encoding issues in the source data.


- Brukte Claude Code til å hjelpe meg med dette, og Claude mener at feilen skyldes at actions/upload-artifact@v3 zipper-fila som kan korumpere data. Analyse fra Claude:

> Importing backup-production-2026-03-09.tar.gz from GitHub Actions fails with:
> ReplacementCharError: Unicode replacement character (U+FFFD) found on line 1
> 
> A local sanity dataset export → sanity dataset import works fine, confirming the issue is in the pipeline, not the data itself.
> 
> Root cause: The backup action uses actions/upload-artifact@v3 (deprecated Nov 2023), which re-compresses the already-gzipped .tar.gz using its own compression layer. This double-compression/decompression cycle can corrupt binary bytes in the NDJSON, replacing them with U+FFFD. Upgrading to v4 with compression-level: 0 avoids re-compressing an already-compressed file.
> 

Edit: Ser at jeg stod i en gammel branch når jeg startet dette arbeidet. Vi var allerede på v4, men hadde ikke compressions-level: 0
